### PR TITLE
Enlarge album art and reduce track text

### DIFF
--- a/frontend/src/components/Dashboard.css
+++ b/frontend/src/components/Dashboard.css
@@ -108,7 +108,7 @@
 .track-card {
   background: var(--surface);
   border-radius: var(--border-radius);
-  padding: 1.5rem;
+  padding: 1rem;
   position: relative;
   transition: var(--transition);
   border: 1px solid rgba(255, 255, 255, 0.1);
@@ -137,13 +137,13 @@
 }
 
 .track-image {
-  margin-bottom: 1rem;
+  margin-bottom: 0.75rem;
   text-align: center;
 }
 
 .track-image img {
-  width: 120px;
-  height: 120px;
+  width: 100%;
+  height: auto;
   border-radius: var(--border-radius);
   object-fit: cover;
 }
@@ -154,23 +154,23 @@
 
 .track-name {
   color: var(--text-primary);
-  font-size: 1.1rem;
-  margin-bottom: 0.5rem;
+  font-size: 1rem;
+  margin-bottom: 0.25rem;
   font-weight: 600;
   line-height: 1.3;
 }
 
 .track-artist {
   color: var(--primary-color);
-  font-size: 0.9rem;
-  margin-bottom: 0.25rem;
+  font-size: 0.85rem;
+  margin-bottom: 0.15rem;
   font-weight: 500;
 }
 
 .track-album {
   color: var(--text-secondary);
-  font-size: 0.8rem;
-  margin-bottom: 1rem;
+  font-size: 0.75rem;
+  margin-bottom: 0.5rem;
 }
 
 .spotify-link {


### PR DESCRIPTION
## Summary
- Emphasize album covers by expanding them to full card width and reducing padding
- Shrink track titles, artist names, and album text to keep focus on cover art

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: ESLint couldn't find a config file)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689c0fa0c104832b939e355b82061a9f