### PR TITLE
Add share button for top albums

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A modern web application that allows users to log in with their Spotify accounts
 - 🔐 **Spotify OAuth Authentication** - Secure login with Spotify accounts using PKCE Flow
 - 🎵 **Top Albums from Your Songs (Current Year)** - We infer your likely top albums this year from your top songs
 - 📄 **Methodology Disclosure** - In-app expandable section explaining how album rankings are computed
+- 📤 **Share Your List** - Copy your ranked top albums as plain text for easy sharing
 - 📱 **Responsive Design** - Works perfectly on desktop and mobile devices
 - 🚀 **GitHub Pages Hosting** - Free hosting with automated deployments
 - ⚡ **Modern Tech Stack** - Built with React, TypeScript, and Vite

--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -36,11 +36,26 @@ const Dashboard: React.FC = () => {
   const [topTracks, setTopTracks] = useState<Track[]>([])
   const [loading, setLoading] = useState(true)
   const [timeRange, setTimeRange] = useState<'short_term' | 'medium_term' | 'long_term'>('medium_term')
-	const [numToFetch, setNumToFetch] = useState<number>(250)
+        const [numToFetch, setNumToFetch] = useState<number>(250)
   const currentYear = new Date().getFullYear()
   const [topAlbums, setTopAlbums] = useState<AlbumEntry[]>([])
   const [showTracks, setShowTracks] = useState<boolean>(false)
   const [showMethodology, setShowMethodology] = useState<boolean>(false)
+
+  const handleShare = () => {
+    const lines = topAlbums.map(
+      (album, idx) => `${idx + 1}. ${album.name} - ${album.artists.join(', ')}`
+    )
+    const text = `My Top Albums of ${currentYear}\n\n${lines.join('\n')}`
+    navigator.clipboard
+      .writeText(text)
+      .then(() => {
+        alert('Top albums copied to clipboard!')
+      })
+      .catch((err) => {
+        console.error('Failed to copy top albums:', err)
+      })
+  }
 
   useEffect(() => {
     if (!isAuthenticated) {
@@ -201,9 +216,16 @@ const Dashboard: React.FC = () => {
         </div>
 
         <div style={{ marginBottom: '1rem' }}>
-          <button className="logout-btn" onClick={() => setShowMethodology(m => !m)}>
-            {showMethodology ? 'Hide methodology' : 'Show methodology'}
-          </button>
+          <div style={{ display: 'flex', gap: '1rem', flexWrap: 'wrap' }}>
+            <button className="logout-btn" onClick={() => setShowMethodology(m => !m)}>
+              {showMethodology ? 'Hide methodology' : 'Show methodology'}
+            </button>
+            {!loading && topAlbums.length > 0 && (
+              <button className="logout-btn" onClick={handleShare}>
+                Copy top albums
+              </button>
+            )}
+          </div>
           {showMethodology && (
             <div style={{ marginTop: '0.75rem', background: 'var(--surface)', padding: '1rem', borderRadius: '8px', border: '1px solid rgba(255,255,255,0.1)' }}>
               <p style={{ color: 'var(--text-secondary)', lineHeight: 1.6 }}>


### PR DESCRIPTION
## Summary
- enable copying top albums as plain text
- document share feature in README

## Testing
- `npm test` *(fails: Missing script "test")*
- `cd frontend && npm run lint` *(fails: ESLint couldn't find configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_689d55a60220832b8bb48bffd9b99677